### PR TITLE
Add a status line for long busy actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up GNAT toolchain
+      run: >
+        sudo apt-get update && 
+        sudo apt-get install gnat gprbuild
+
+    - name: Build
+      run: gprbuild -j0 -p

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build](https://github.com/alire-project/simple_logging/workflows/Build/badge.svg)](https://github.com/alire-project/simple_logging/actions)
+
 # simple_logging
 
 Easy-to-use logging facilities for output to console in Ada programs.

--- a/src/simple_logging-decorators.adb
+++ b/src/simple_logging-decorators.adb
@@ -1,0 +1,54 @@
+with Simple_Logging.Support;
+
+package body Simple_Logging.Decorators is
+
+   ------------
+   -- Prefix --
+   ------------
+
+   function Prefix (Level : Levels) return String is
+     (case Level is
+         when Always  => "",
+         when Error   => "ERROR: ",
+         when WARNING => "Warning: ",
+         when Info    => "",
+         when Detail  => "-> ",
+         when Debug   => "-->> ");
+
+   -----------------------------
+   -- Default_Level_Decorator --
+   -----------------------------
+
+   function Default_Level_Decorator (Level   : Levels;
+                                     Message : String)
+                                     return String is
+     (Prefix (Level) & Message);
+
+   --------------------------------
+   -- Default_Location_Decorator --
+   --------------------------------
+
+   function No_Location_Decorator (Entity,
+                                   Location,
+                                   Message : String) return String is
+      pragma Unreferenced (Location, Entity);
+   begin
+      return Message;
+   end No_Location_Decorator;
+
+   -------------------------------
+   -- Simple_Location_Decorator --
+   -------------------------------
+
+   function Simple_Location_Decorator (Entity,
+                                       Location,
+                                       Message : String) return String is
+     ("[" & Support.Rpad ((if Entity'Length <= Entity_Width
+                   then Entity
+                   else Support.Elide (Entity, Entity_Width)), Entity_Width) & "]"
+      & " (" & Support.Rpad ((if Location'Length <= Location_Width
+                   then Location
+                   else Support.Elide (Location, Location_Width)), Location_Width) & ")"
+      & " " & Message);
+
+end Simple_Logging.Decorators;

--- a/src/simple_logging-decorators.ads
+++ b/src/simple_logging-decorators.ads
@@ -1,0 +1,48 @@
+package Simple_Logging.Decorators with Preelaborate is
+
+   --------------
+   -- Defaults --
+   --------------
+   --  These functions are used by default for log decoration.
+   --  They take the log message and modify it somehow.
+
+   function Default_Level_Decorator (Level   : Levels;
+                                     Message : String)
+                                     return String;
+   --  Prefixes the log message with ERROR/Warning/(nothing)/->/-->>.
+
+   function No_Location_Decorator (Entity,
+                                   Location,
+                                   Message : String) return String;
+   --  Does not use the location/entity information, Message is kept as-is.
+
+   Location_Width : Positive range 2 .. Positive'Last := 24;
+   Entity_Width   : Positive range 2 .. Positive'Last := 24;
+
+   function Simple_Location_Decorator (Entity,
+                                       Location,
+                                       Message : String) return String;
+   --  Prefixes the log message with fixed-with entity/location.
+   --  Uses the previous two declared variables for the width.
+
+   -------------------
+   -- Configuration --
+   -------------------
+   --  These are the functions that the user can set to other preferred values.
+
+   --  The output message is:
+   --  Location_Decorator (Level_Decorator (Message))
+
+   Level_Decorator : access function (Level : Levels;
+                                      Message : String) return String :=
+     Default_Level_Decorator'Access;
+   --  Use simple text prefixes for normal levels, markers for verbose levels.
+
+   Location_Decorator : access function (Entity,
+                                         Location,
+                                         Message : String) return String :=
+     No_Location_Decorator'Access;
+   --  No entity/location information by default.
+   --  See Simple_Location_Decorator above for a "[entity] (location) Msg" option.
+
+end Simple_Logging.Decorators;

--- a/src/simple_logging-filtering.adb
+++ b/src/simple_logging-filtering.adb
@@ -1,0 +1,17 @@
+package body Simple_Logging.Filtering is
+
+   --------------------
+   -- Default_Filter --
+   --------------------
+
+   function Default_Filter (Message  : String;
+                            Level    : Levels;
+                            Entity   : String;
+                            Location : String) return Boolean is
+     (True);
+
+   procedure Add_Substring (Str : String) is null;
+
+   procedure Add_Exception (Str : String) is null;
+
+end Simple_Logging.Filtering;

--- a/src/simple_logging-filtering.adb
+++ b/src/simple_logging-filtering.adb
@@ -1,4 +1,29 @@
+with Ada.Characters.Handling;
+with Ada.Containers.Indefinite_Ordered_Sets;
+with Ada.Exceptions;
+with Ada.Strings.Fixed;
+
+with GNAT.IO;
+
+with Simple_Logging.Decorators;
+
 package body Simple_Logging.Filtering is
+
+   package String_Sets is new Ada.Containers.Indefinite_Ordered_Sets (String);
+
+   Substrings : String_Sets.Set;
+
+   Exceptions : String_Sets.Set;
+
+   --------------
+   -- Contains --
+   --------------
+
+   function Contains (Text, Substring : String) return Boolean is
+     (Ada.Strings.Fixed.Index
+        (Ada.Characters.Handling.To_Lower (Text), Substring) > 0);
+   --  patterns are lowercased on agregation.
+
 
    --------------------
    -- Default_Filter --
@@ -7,11 +32,196 @@ package body Simple_Logging.Filtering is
    function Default_Filter (Message  : String;
                             Level    : Levels;
                             Entity   : String;
-                            Location : String) return Boolean is
-     (True);
+                            Location : String) return Boolean
+   is
+      pragma Unreferenced (Message, Level);
+      Found  : Boolean := False;
+      Except : Boolean := False;
+   begin
+      for Str of Substrings loop
+         if Contains (Entity, Str) or else Contains (Location, Str) then
+            Found := True;
+            exit;
+         end if;
+      end loop;
 
-   procedure Add_Substring (Str : String) is null;
+      if Found then
+         for Str of Exceptions loop
+            if Contains (Entity, Str) or else Contains (Location, Str) then
+               Except := True;
+               exit;
+            end if;
+         end loop;
+      end if;
 
-   procedure Add_Exception (Str : String) is null;
+      return
+        (Mode = Blacklist and then (not Found or else Except)) or else
+        (Mode = Whitelist and then (Found and then not Except));
+   end Default_Filter;
+
+   -------------------
+   -- Add_Substring --
+   -------------------
+
+   procedure Add_Substring (Str : String) is
+   begin
+      Substrings.Include (Ada.Characters.Handling.To_Lower (Str));
+   end Add_Substring;
+
+   -------------------
+   -- Add_Exception --
+   -------------------
+
+   procedure Add_Exception (Str : String) is
+   begin
+      Exceptions.Include (Ada.Characters.Handling.To_Lower (Str));
+   end Add_Exception;
+
+   ---------------------
+   -- Add_From_String --
+   ---------------------
+
+   function Add_From_String (Str : String;
+                             Say : Boolean := False) return Boolean is
+
+      Bad_Syntax : exception;
+
+      ----------------
+      -- Add_Scopes --
+      ----------------
+
+      procedure Add_Scopes (Debug_Arg : String) is
+         --  Receives as-is the --debug/-d[ARG] argument. This is a list of
+         --  optionally comma-separated, plus/minus prefixed substrings that will
+         --  be used for filtering against the enclosing entity/source location.
+         --  Example whitelisting argument: +commands,-search
+         --  Example blacklisting argument: -commands,+search
+         --  The first sign puts the filter in (-) blacklist / (+) whitelist mode.
+         --  In whitelist mode, only the given substrings are logged, unless later
+         --  added as exception. E.g., in the "+commands,-search" example, only
+         --  commands traces would be logged (because of whitelist mode), except
+         --  the ones for the search command (because given as an exception).
+         --  In the "-commands,+search" example for blacklist mode, everything but
+         --  command traces would be logged, but search command traces would be
+         --  logged because that's the exception.
+
+         --  Once scopes are used, we activate logging of enclosing entity and
+         --  location to provide full logging information.
+
+         Pos : Integer := Debug_Arg'First;
+         --  Points to the beginning of the next scope in Debug_Arg
+
+         --------------------
+         -- Next_With_Sign --
+         --------------------
+
+         function Next_With_Sign return String is
+            --  Look from Debug_Arg (Pos) onwards to find a comma, sign, or end.
+            --  Returns "" when no more scopes. Otherwise, returns a single scope
+            --  with its sign (e.g., "+commands")
+            Old_Pos : constant Integer := Pos;
+         begin
+            if Pos >= Debug_Arg'Last then
+               return "";
+            end if;
+
+            for I in Pos + 1 .. Debug_Arg'Last loop
+               if Debug_Arg (I) in ',' | '+' | '-' then
+                  if Pos = I - 1 then -- Means consecutive separators, i.e. no-no
+                     raise Bad_Syntax with "Invalid logging scope separator: " & Debug_Arg;
+                  end if;
+
+                  Pos := I;
+                  if Debug_Arg (Pos) = ',' then
+                     Pos := Pos + 1;
+                  end if;
+                  return Debug_Arg (Old_Pos .. I - 1);
+               end if;
+            end loop;
+
+            --  We reached the end:
+            Pos := Debug_Arg'Last + 1;
+            return Debug_Arg (Old_Pos .. Debug_Arg'Last);
+         end Next_With_Sign;
+
+      begin
+         if Str = "" then
+            return;
+         end if;
+
+         --  Activate scope logging:
+         Decorators.Location_Decorator :=
+           Decorators.Simple_Location_Decorator'Access;
+
+         case Debug_Arg (Str'First) is
+            when '+' =>
+               Simple_Logging.Filtering.Mode := Whitelist;
+            when '-' =>
+               Simple_Logging.Filtering.Mode := Blacklist;
+            when others =>
+               raise Bad_Syntax
+                 with "Debug filters must be prefixed with + or -.";
+         end case;
+
+         --  Output how we are going to filter:
+         if Say then
+            GNAT.IO.Put_Line ("Filtering mode: "
+                              & Simple_Logging.Filtering.Mode'Img);
+         end if;
+
+         --  Process scopes according to mode and sign
+         loop
+            declare
+               Scope_With_Sign : constant String := Next_With_Sign;
+            begin
+               --  Nothing more to process
+               if Scope_With_Sign = "" then
+                  return;
+               end if;
+
+               --  Add a single scope
+               declare
+                  Sign  : constant Character :=
+                            Scope_With_Sign (Scope_With_Sign'First);
+                  Scope : constant String :=
+                            Scope_With_Sign (Scope_With_Sign'First + 1 ..
+                                                       Scope_With_Sign'Last);
+               begin
+                  if Sign not in '-' | '+' then
+                     raise Bad_Syntax with
+                       "ERROR: Missing +/- before filter: " & Scope_With_Sign;
+                  end if;
+
+                  if (Filtering.Mode = Filtering.Blacklist and then Sign = '-') or
+                    (Filtering.Mode = Filtering.Whitelist and then Sign = '+')
+                  then
+                     if Say then
+                        GNAT.IO.Put_Line ("Filtering substring: " & Scope);
+                     end if;
+                     Filtering.Add_Substring (Scope);
+                  else
+                     if Say then
+                        GNAT.IO.Put_Line ("Filtering exception: " & Scope);
+                     end if;
+                     Filtering.Add_Exception (Scope);
+                  end if;
+               end;
+            end;
+         end loop;
+      end Add_Scopes;
+
+   begin
+      Add_Scopes (Str);
+      return True;
+   exception
+      when E : Bad_Syntax =>
+         Mode := Blacklist;
+         Substrings.Clear;
+         Exceptions.Clear;
+         if Say then
+            GNAT.IO.Put_Line (Ada.Exceptions.Exception_Message (E));
+         end if;
+         return False;
+   end Add_From_String;
 
 end Simple_Logging.Filtering;

--- a/src/simple_logging-filtering.ads
+++ b/src/simple_logging-filtering.ads
@@ -1,0 +1,48 @@
+package Simple_Logging.Filtering with Preelaborate is
+
+   --  Filtering enables to accept/filter out messages that will get displayed.
+   --  By default, no filtering occurs.
+   --  See below how to configure the default filter.
+
+   function Default_Filter (Message  : String;
+                            Level    : Levels;
+                            Entity   : String;
+                            Location : String) return Boolean;
+   --  The default filter accepts everything, unless configured with the calls
+   --  below.
+   --  The implementation doesn't strive to be super-efficient; it only
+   --  guarantees logarithmic degradation on look-up times.
+
+   -------------------
+   -- Configuration --
+   -------------------
+
+   --  The following function can be changed to an entirely new filter.
+   --  Otherwise, see below for configuration options for the default filter.
+
+   Accept_Message : access function (Message  : String;
+                                     Level    : Levels;
+                                     Entity   : String;
+                                     Location : String) return Boolean :=
+     Default_Filter'Access;
+
+   type Filtering_Modes is (Blacklist, Whitelist);
+   --  In blacklist mode, by default all passes but explicitly blacklisted.
+   --  In whitelist mode, nothing passes but whitelisted.
+   --  En each mode, you can further add exceptions to the list that operate
+   --  in the contrary mode.
+
+   Mode : Filtering_Modes := Blacklist;
+   --  MOde for the Default_Filter
+
+   procedure Add_Substring (Str : String);
+   --  Something that will be blacklisted/whitelisted.
+   --  It case-insensitively checks the Location and the Entity of the message.
+
+   procedure Add_Exception (Str : String);
+   --  Add an exception to the regular mode. For example, in Blacklist mode:
+   --  Add_Substring ("foo"); -- blacklists messages containing "foo"
+   --  Add_Exception ("bar"); -- unless they contain "bar" too.
+   --  In whitelist mode, something similar but in reverse will happen.
+
+end Simple_Logging.Filtering;

--- a/src/simple_logging-filtering.ads
+++ b/src/simple_logging-filtering.ads
@@ -45,4 +45,18 @@ package Simple_Logging.Filtering with Preelaborate is
    --  Add_Exception ("bar"); -- unless they contain "bar" too.
    --  In whitelist mode, something similar but in reverse will happen.
 
+   function Add_From_String (Str : String;
+                             Say : Boolean := False) return Boolean;
+   --  Process an entire string (e.g. coming from a command-line argument) to
+   --  configure filtering. String syntax is: (+|-)[scope][[,](+|-)scope]...
+   --  Will return False if syntax is wrong. Lists will be emptied in that case.
+   --  If Say = True, the mode/scopes will be written to stdout for reference.
+   --  Examples:
+   --    + (empty whitelist, nothing will pass)
+   --    +foo,-bar (whitelist foo, except bar)
+   --    - (empty blacklist, nothing will be blocked)
+   --    -foo,+bar (blacklist foo, except bar)
+   --    -foo+bar (commas are optional)
+   --  The very first sign sets the mode to whitelist (+) or blacklist (-).
+
 end Simple_Logging.Filtering;

--- a/src/simple_logging-support.adb
+++ b/src/simple_logging-support.adb
@@ -1,0 +1,25 @@
+package body Simple_Logging.Support is
+
+   -----------
+   -- Elide --
+   -----------
+
+   function Elide (Str : String; Len : Natural; Ellipsis : String := "..")
+                   return String is
+     (if Str'Length <= Len
+      then Str
+      else Ellipsis &
+           Str (Str'First + (Str'Length - Len + Ellipsis'Length) ..
+                Str'Last));
+   
+   ----------
+   -- Rpad --
+   ----------
+
+   function Rpad (Str : String; Len : Natural; Char : Character := ' ')
+                  return String is
+     (if Str'Length >= Len
+      then Str
+      else Str & String'(1 .. Len - Str'Length => Char));
+
+end Simple_Logging.Support;

--- a/src/simple_logging-support.ads
+++ b/src/simple_logging-support.ads
@@ -1,0 +1,19 @@
+package Simple_Logging.Support with Preelaborate is
+
+   -----------
+   -- Elide --
+   -----------
+
+   function Elide (Str : String; Len : Natural; Ellipsis : String := "..")
+                   return String;
+   --  If Str'Lenght > Len, return "..remainder_of_string".
+   
+   ----------
+   -- Rpad --
+   ----------
+
+   function Rpad (Str : String; Len : Natural; Char : Character := ' ')
+                  return String;
+   --  Left-justify String by padding with Char on the right.
+
+end Simple_Logging.Support;

--- a/src/simple_logging.adb
+++ b/src/simple_logging.adb
@@ -1,24 +1,29 @@
 with GNAT.IO;
 
-package body Simple_Logging is
+with Simple_Logging.Decorators;
+with Simple_Logging.Filtering;
 
-   function Prefix (Level : Levels) return String is
-     (case Level is
-         when Always  => "",
-         when Error   => "ERROR: ",
-         when WARNING => "Warning: ",
-         when Info    => "",
-         when Detail  => "-> ",
-         when Debug   => "-->> ");
+package body Simple_Logging is
 
    ---------
    -- Log --
    ---------
 
-   procedure Log (S : String; Level : Levels := Info) is
+   procedure Log (Message  : String;
+                  Level    : Levels := Info;
+                  Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                  Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      if Level <= Simple_Logging.Level then
-         GNAT.IO.Put_Line (Prefix (Level) & S);
+      if Level <= Simple_Logging.Level and then
+        Filtering.Accept_Message (Message, Level, Entity, Location)
+      then
+         GNAT.IO.Put_Line
+           (Decorators.Location_Decorator
+              (Entity,
+               Location,
+               Decorators.Level_Decorator
+                 (Level,
+                  Message)));
       end if;
    end Log;
 
@@ -26,54 +31,66 @@ package body Simple_Logging is
    -- Always --
    ------------
 
-   procedure Always  (Msg : String) is
+   procedure Always  (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      Log (Msg, Always);
+      Log (Msg, Always, Entity, Location);
    end Always;
 
    -----------
    -- Error --
    -----------
 
-   procedure Error   (Msg : String) is
+   procedure Error   (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      Log (Msg, Error);
+      Log (Msg, Error, Entity, Location);
    end Error;
 
    -------------
    -- Warning --
    -------------
 
-   procedure Warning (Msg : String) is
+   procedure Warning (Msg : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      Log (Msg, Warning);
+      Log (Msg, Warning, Entity, Location);
    end Warning;
 
    ----------
    -- Info --
    ----------
 
-   procedure Info    (Msg : String) is
+   procedure Info    (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      Log (Msg, Info);
+      Log (Msg, Info, Entity, Location);
    end Info;
 
    ------------
    -- Detail --
    ------------
 
-   procedure Detail  (Msg : String) is
+   procedure Detail  (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      Log (Msg, Detail);
+      Log (Msg, Detail, Entity, Location);
    end Detail;
 
    -----------
    -- Debug --
    -----------
 
-   procedure Debug   (Msg : String) is
+   procedure Debug   (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location) is
    begin
-      Log (Msg, Debug);
+      Log (Msg, Debug, Entity, Location);
    end Debug;
 
 end Simple_Logging;

--- a/src/simple_logging.ads
+++ b/src/simple_logging.ads
@@ -1,6 +1,11 @@
 with GNAT.Source_Info;
 
+private with Ada.Finalization;
+
 package Simple_Logging with Preelaborate is
+
+   --  NOTE: this library is thread-unsafe. Using it with multithreaded
+   --  applications will likely result in mangled output.
 
    --  Since the purpose is to have simultaneously "simple" yet flexible
    --  logging, this package enables the configuration of a single logger
@@ -52,5 +57,45 @@ package Simple_Logging with Preelaborate is
                       Entity   : String := Gnat.Source_Info.Enclosing_Entity;
                       Location : String := Gnat.Source_Info.Source_Location)
    is null; -- Quietly drop
+
+   -----------------
+   -- Status line --
+   -----------------
+
+   type Ongoing (<>) is tagged limited private;
+   --  The status line is used to present an ongoing activity. This is done
+   --  through a scoped type. Several nested statuses can be created, and the
+   --  trailing '...' is added by this prompt. The rest of logging subprograms
+   --  will emit normally over the status line.
+
+   function Activity (Text : String;
+                      Level : Levels := Info) return Ongoing;
+
+   procedure Step (This : in out Ongoing);
+   --  Say that progress was made, which will advance the spinner
+
+private
+
+   type Ongoing_Data (Len : Natural) is record
+      Level : Levels;
+      Text  : String (1 .. Len);
+   end record;
+   --  Non-limited data to be stored in collections
+
+   type Ongoing (Len : Natural)
+   is new Ada.Finalization.Limited_Controlled with record
+      Data : Ongoing_Data (Len => Len);
+   end record;
+
+   function "<" (L, R : Ongoing_Data) return Boolean is
+     (L.Level < R.Level or else
+      (L.Level = R.Level and then L.Text < R.Text));
+
+   overriding
+   procedure Finalize (This : in out Ongoing);
+
+   function Build_Status_Line return String;
+
+   procedure Clear_Status_Line;
 
 end Simple_Logging;

--- a/src/simple_logging.ads
+++ b/src/simple_logging.ads
@@ -1,4 +1,12 @@
+with GNAT.Source_Info;
+
 package Simple_Logging with Preelaborate is
+
+   --  Since the purpose is to have simultaneously "simple" yet flexible
+   --  logging, this package enables the configuration of a single logger
+   --  to console.
+   --  That said, a number of customization options are available with the
+   --  Decorators/Filtering child packages.
 
    type Levels is (Always,
                    Error,
@@ -12,18 +20,37 @@ package Simple_Logging with Preelaborate is
    Level : Levels := Info;
    --  Any message at the same level or below will be output to console
 
-   procedure Log (S : String; Level : Levels := Info);
+   procedure Log (Message  : String;
+                  Level    : Levels := Info;
+                  Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                  Location : String := Gnat.Source_Info.Source_Location);
    --  Report a log message
 
    --  Log by level.
-   --  Useful if you want to use a package renaming as prefix, e.g.: Log.Info ("Blah");
+   --  Useful if you want to use a package renaming as prefix,
+   --  e.g. : Log.Info ("Blah");
 
-   procedure Always  (Msg : String);
-   procedure Error   (Msg : String);
-   procedure Warning (Msg : String);
-   procedure Info    (Msg : String);
-   procedure Detail  (Msg : String);
-   procedure Debug   (Msg : String);
-   procedure Never   (Msg : String) is null; -- Quietly drop
+   procedure Always  (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location);
+   procedure Error   (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location);
+   procedure Warning (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location);
+   procedure Info    (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location);
+   procedure Detail  (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location);
+   procedure Debug   (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location);
+   procedure Never   (Msg      : String;
+                      Entity   : String := Gnat.Source_Info.Enclosing_Entity;
+                      Location : String := Gnat.Source_Info.Source_Location)
+   is null; -- Quietly drop
 
 end Simple_Logging;

--- a/src/simple_logging.ads
+++ b/src/simple_logging.ads
@@ -7,6 +7,7 @@ package Simple_Logging with Preelaborate is
                    Detail,
                    Debug);
    --  From most important to less important
+   --  Or, from less verbose to more verbose
 
    Level : Levels := Info;
    --  Any message at the same level or below will be output to console


### PR DESCRIPTION
The status line appears below all normal log messages whenever a busy status is alive. Regular logs can still be output, and scroll up above the status line.

Busy statuses are created with a controlled object that will autoremove the status once it goes out of scope. In case of nested instances, they're appended, e.g.:

`◴ Looking for externals... Detecting libsdl2...`

The implementation relies on basic carriage return characters, so it should work in common terminals.